### PR TITLE
Updated the guide to use version 1.8 of influxdb

### DIFF
--- a/influxdb/runinfluxdb.sh
+++ b/influxdb/runinfluxdb.sh
@@ -9,5 +9,5 @@ sudo docker run --detach --net=host \
 	--hostname influxdb \
 	--restart=always \
  	-p 8086:8086 \
-        --name influxdb influxdb:latest
+        --name influxdb influxdb:1.8
 


### PR DESCRIPTION
The guide does not work with latest version of influxdb 2.x due to changes in Go lang and TLS requiring go-mssql to support SetWriteDeadline which is not currently supported https://github.com/denisenkom/go-mssqldb/blob/master/net.go#L127.