### PR TITLE
Grafana container doesn't start due to Azure Monitor Plugin 

### DIFF
--- a/grafana/rungrafana.sh
+++ b/grafana/rungrafana.sh
@@ -6,7 +6,7 @@ GRAFANA_HOST_DIRECTORY="/data/grafana"
 
 sudo docker run --user root  --detach -p 3000:3000 --net=host --restart=always \
 	-v $GRAFANA_HOST_DIRECTORY:/var/lib/grafana \
-	-e "GF_INSTALL_PLUGINS=grafana-azure-monitor-datasource,grafana-piechart-panel,savantly-heatmap-panel" \
+	-e "GF_INSTALL_PLUGINS=grafana-piechart-panel,savantly-heatmap-panel" \
 	--name grafana grafana/grafana
 
 


### PR DESCRIPTION
I was getting error

Error: ✗ Plugin not found (Grafana v9.0.2 linux-amd64)

As per documentation https://grafana.com/grafana/plugins/grafana-azure-monitor-datasource/?tab=installation

This plugin is included with Grafana and does not require installation. Woo.

Removing the Plugin works.